### PR TITLE
Add support for nullable(*) and fixedstring(*) datatypes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,11 @@ authors = ["Joel Höner <athre0z@zyantific.com>"]
 version = "0.1.0"
 
 [deps]
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
-CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/src/ClickHouse.jl
+++ b/src/ClickHouse.jl
@@ -13,5 +13,7 @@ export select_df_channel
 export insert
 export execute
 export connect
+export ping
+export ClickHouseServerException
 
 end # module

--- a/src/ClickHouse.jl
+++ b/src/ClickHouse.jl
@@ -5,14 +5,13 @@ include("Query.jl")
 
 export ClickHouseSock
 export Block
-export select_into_chunks
+export select
 export select_callback
-export select_as_dict
-export select_as_df
+export select_channel
+export select_df
+export select_df_channel
 export insert
 export execute
 export connect
-export ping
-export ClickHouseServerException
 
 end # module

--- a/src/ClickHouse.jl
+++ b/src/ClickHouse.jl
@@ -5,10 +5,10 @@ include("Query.jl")
 
 export ClickHouseSock
 export Block
-export select
+export select_into_chunks
 export select_callback
-export select_channel
-export select_df
+export select_as_dict
+export select_as_df
 export insert
 export execute
 export connect

--- a/src/Net.jl
+++ b/src/Net.jl
@@ -266,6 +266,7 @@ function read_col(sock::ClickHouseSock, num_rows::VarUInt)::Column
         match(NULLABLE_RE, type_name)[1]
     else
         type_name
+    end
 
     decode_type_name, enum_def = if startswith(type_name, "Enum")
         parse_enum_def(type_name)

--- a/src/Query.jl
+++ b/src/Query.jl
@@ -216,7 +216,7 @@ function select_callback(
 end
 
 "Execute a query, streaming the resulting blocks through a channel."
-function select_into_chunks(
+function select_df_channel(
     sock::ClickHouseSock,
     query::AbstractString;
     csize = 0,
@@ -229,8 +229,21 @@ function select_into_chunks(
     end
 end
 
+function select_channel(
+    sock::ClickHouseSock,
+    query::AbstractString;
+    csize = 0,
+    kwargs...,
+)::Channel{Dict{Symbol, Any}}
+    Channel(ctype = Dict{Symbol, Any}, csize = csize) do ch
+        select_callback(sock, query; kwargs...) do row
+                put!(ch, row)
+        end
+    end
+end
+
 "Execute a query, flattening blocks into a single dict of column arrays."
-function select_as_dict(
+function select(
     sock::ClickHouseSock,
     query::AbstractString;
     kwargs...
@@ -250,12 +263,12 @@ function select_as_dict(
 end
 
 "Execute a query, flattening blocks into a dataframe."
-function select_as_df(
+function select_df(
     sock::ClickHouseSock,
     query::AbstractString;
     kwargs...
 )::DataFrame
-    DataFrame(select_as_dict(sock, query; kwargs...))
+    DataFrame(select(sock, query; kwargs...))
 end
 
 # ============================================================================ #

--- a/src/Query.jl
+++ b/src/Query.jl
@@ -217,7 +217,7 @@ end
 
 "Execute a query, streaming the resulting blocks through a channel."
 function select_df_channel(
-    sock::ClickHouseSock,
+    sock::ClickHouseSock = connect(),
     query::AbstractString;
     csize = 0,
     kwargs...,
@@ -230,7 +230,7 @@ function select_df_channel(
 end
 
 function select_channel(
-    sock::ClickHouseSock,
+    sock::ClickHouseSock = connect(),
     query::AbstractString;
     csize = 0,
     kwargs...,
@@ -244,7 +244,7 @@ end
 
 "Execute a query, flattening blocks into a single dict of column arrays."
 function select(
-    sock::ClickHouseSock,
+    sock::ClickHouseSock = connect(),
     query::AbstractString;
     kwargs...
 )::Dict{Symbol, Any}
@@ -264,7 +264,7 @@ end
 
 "Execute a query, flattening blocks into a dataframe."
 function select_df(
-    sock::ClickHouseSock,
+    sock::ClickHouseSock = connect(),
     query::AbstractString;
     kwargs...
 )::DataFrame

--- a/src/Query.jl
+++ b/src/Query.jl
@@ -217,8 +217,8 @@ end
 
 "Execute a query, streaming the resulting blocks through a channel."
 function select_df_channel(
-    sock::ClickHouseSock = connect(),
-    query::AbstractString;
+    query::AbstractString,
+    sock::ClickHouseSock = connect();
     csize = 0,
     kwargs...,
 )::Channel{DataFrame}
@@ -230,8 +230,8 @@ function select_df_channel(
 end
 
 function select_channel(
-    sock::ClickHouseSock = connect(),
-    query::AbstractString;
+    query::AbstractString,
+    sock::ClickHouseSock = connect();
     csize = 0,
     kwargs...,
 )::Channel{Dict{Symbol, Any}}
@@ -244,8 +244,8 @@ end
 
 "Execute a query, flattening blocks into a single dict of column arrays."
 function select(
-    sock::ClickHouseSock = connect(),
-    query::AbstractString;
+    query::AbstractString,
+    sock::ClickHouseSock = connect();
     kwargs...
 )::Dict{Symbol, Any}
     result = Dict{Symbol, Any}()
@@ -264,8 +264,8 @@ end
 
 "Execute a query, flattening blocks into a dataframe."
 function select_df(
-    sock::ClickHouseSock = connect(),
-    query::AbstractString;
+    query::AbstractString,
+    sock::ClickHouseSock = connect();
     kwargs...
 )::DataFrame
     DataFrame(select(sock, query; kwargs...))

--- a/src/Query.jl
+++ b/src/Query.jl
@@ -237,7 +237,7 @@ function select_channel(
 )::Channel{Dict{Symbol, Any}}
     Channel(ctype = Dict{Symbol, Any}, csize = csize) do ch
         select_callback(sock, query; kwargs...) do row
-                put!(ch, row)
+            put!(ch, row)
         end
     end
 end

--- a/src/Query.jl
+++ b/src/Query.jl
@@ -268,7 +268,7 @@ function select_df(
     sock::ClickHouseSock = connect();
     kwargs...
 )::DataFrame
-    DataFrame(select(sock, query; kwargs...))
+    DataFrame(select(query, sock; kwargs...))
 end
 
 # ============================================================================ #


### PR DESCRIPTION
- Support selecting data with nullable-type or fixstring-type columns
- Enum types in ClickHouse are now imported as CategoricalArrays
- a new function "select_df_stream" to stream the dataframe-type results